### PR TITLE
Update assignable predicate for Angular 0.9.4

### DIFF
--- a/lib/angular_node_bind.dart
+++ b/lib/angular_node_bind.dart
@@ -58,7 +58,7 @@ class NodeBindDirective {
       if (exprMatch != null) {
         var expr = exprMatch[1];
         Expression expression = parser(expr);
-        if (expression.assignable) {
+        if (expression.isAssignable) {
           box.changes.listen((_) => expression.assign(scope, box.value));
         }
         scope.$watch(expression.eval, (value, _) => box.value = value,


### PR DESCRIPTION
This seems to have changed somewhat recent-ish. Without this, I am unable to get angular_node_bind to work with current Angular.dart
