### PR TITLE
Update watch for Angular 1.0

### DIFF
--- a/lib/angular_node_bind.dart
+++ b/lib/angular_node_bind.dart
@@ -66,8 +66,8 @@ class NodeBindDirective {
         scope.watch(expr, box.update);
       } else {
         var interpolation = interpolate(value, false, '[[', ']]');
-        print("interpolation: $interpolation");
-        scope.watch(interpolation, box.update, formatters: formatterMap);
+        print("interpolation: $interpolation.expression");
+        scope.watch(interpolation.expression, box.update, formatters: formatterMap);
       }
     }
   }


### PR DESCRIPTION
Need to watch the interpolation expression now instead of the interpolation itself.

I might suggest that the `print()` on line 69 be deleted, but I have updated it as well for now.
